### PR TITLE
OCPBUGS-512: Change FSGroupPolicy to File

### DIFF
--- a/assets/csidriver.yaml
+++ b/assets/csidriver.yaml
@@ -8,3 +8,4 @@ metadata:
 spec:
   attachRequired: false
   podInfoOnMount: true
+  fsGroupPolicy: File


### PR DESCRIPTION
I missed this overlay in the upstream repository: https://github.com/kubernetes-sigs/gcp-filestore-csi-driver/blob/master/deploy/kubernetes/overlays/stable-master/fsgrouppolicy.yaml

CC @openshift/storage 
