### PR TITLE
fix naming convention

### DIFF
--- a/config/manifests/art.yaml
+++ b/config/manifests/art.yaml
@@ -3,7 +3,7 @@ updates:
     update_list:
     # replace metadata.name value
     - search: "gcp-filestore-csi-driver-operator.v{MAJOR}.{MINOR}.0"
-      replace: "gcp-filestore-csi-driver-operator.{FULL_VER}"
+      replace: "gcp-filestore-csi-driver-operator.v{FULL_VER}"
     # replace entire version line, otherwise would replace 4.3.0 anywhere
     - search: "version: {MAJOR}.{MINOR}.0"
       replace: "version: {FULL_VER}"


### PR DESCRIPTION
there is a warning reported in CVP check for 4.12
http://external-ci-coldstorage.datahub.redhat.com/cvp/cvp-redhat-operator-bundle-image-validation-test/ose-gcp-filestore-csi-driver-operator-bundle-container-v4.12.0.202211081106.p0.g7ed738d.assembly.stream-1/89c318d8-7256-463d-8e88-263e5103d457/operator-metadata-linting-bundle-image-output.txt
I think this could be a common issue, so pr against master can cherry-pick to 4.12 branch later.