### PR TITLE
STOR-1078: Add hostPaths necessary for SELinux mounts

### DIFF
--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -51,6 +51,10 @@ spec:
               mountPropagation: "Bidirectional"
             - name: plugin-dir
               mountPath: /csi
+            - name: etc-selinux
+              mountPath: /etc/selinux
+            - name: sys-fs
+              mountPath: /sys/fs
           ports:
             - name: healthz
               # Due to hostNetwork, this port is open on a node and cannot
@@ -127,4 +131,12 @@ spec:
         - name: registration-dir
           hostPath:
             path: /var/lib/kubelet/plugins_registry/
+            type: Directory
+        - name: etc-selinux
+          hostPath:
+            path: /etc/selinux
+            type: DirectoryOrCreate
+        - name: sys-fs
+          hostPath:
+            path: /sys/fs
             type: Directory


### PR DESCRIPTION
To support "mount -o context=XYZ", /etc/selinux and /sys/fs/selinux from the host must be present in the CSI driver container.

cc @openshift/storage 