### PR TITLE
OCPBUGS-11806: Bump version to 4.14

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ IMAGE_REGISTRY?=registry.svc.ci.openshift.org
 # $3 - Dockerfile path
 # $4 - context directory for image build
 # It will generate target "image-$(1)" for building the image and binding it as a prerequisite to target "images".
-$(call build-image,gcp-filestore-csi-driver-operator,$(IMAGE_REGISTRY)/ocp/4.13:gcp-filestore-csi-driver-operator,./Dockerfile.rhel7,.)
+$(call build-image,gcp-filestore-csi-driver-operator,$(IMAGE_REGISTRY)/ocp/4.14:gcp-filestore-csi-driver-operator,./Dockerfile.rhel7,.)
 
 clean:
 	$(RM) gcp-filestore-csi-driver-operator

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ To build an bundle and index images, use the `hack/create-bundle` script:
 
 ```shell
 cd hack
-./create-bundle registry.ci.openshift.org/ocp/4.13:gcp-filestore-csi-driver registry.ci.openshift.org/ocp/4.13:gcp-filestore-csi-driver-operator quay.io/<my_user>/filestore-bundle quay.io/<my_user>/filestore-index
+./create-bundle registry.ci.openshift.org/ocp/4.14:gcp-filestore-csi-driver registry.ci.openshift.org/ocp/4.14:gcp-filestore-csi-driver-operator quay.io/<my_user>/filestore-bundle quay.io/<my_user>/filestore-index
 ```
 
 At the end it will print a command that creates `Subscription` for the newly created index image.

--- a/config/manifests/gcp-filestore-csi-driver-operator.package.yaml
+++ b/config/manifests/gcp-filestore-csi-driver-operator.package.yaml
@@ -1,4 +1,4 @@
 packageName: gcp-filestore-csi-driver-operator
 channels:
 - name: preview
-  currentCSV: gcp-filestore-csi-driver-operator.v4.13.0
+  currentCSV: gcp-filestore-csi-driver-operator.v4.14.0

--- a/config/manifests/preview/gcp-filestore-csi-driver-operator.clusterserviceversion.yaml
+++ b/config/manifests/preview/gcp-filestore-csi-driver-operator.clusterserviceversion.yaml
@@ -1,7 +1,7 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
-  name: gcp-filestore-csi-driver-operator.v4.13.0
+  name: gcp-filestore-csi-driver-operator.v4.14.0
   namespace: placeholder
   annotations:
     categories: Storage
@@ -13,7 +13,7 @@ metadata:
     repository: https://github.com/openshift/gcp-filestore-csi-driver-operator
     createdAt: "2021-07-14T00:00:00Z"
     description: Install and configure GCP Filestore CSI driver.
-    olm.skipRange: ">=4.11.0-0 <4.13.0"
+    olm.skipRange: ">=4.11.0-0 <4.14.0"
   labels:
     operator-metering: "true"
     "operatorframework.io/arch.amd64": supported
@@ -36,7 +36,7 @@ spec:
       url: https://github.com/openshift/gcp-filestore-csi-driver-operator
     - name: Source Repository
       url: https://github.com/openshift/gcp-filestore-csi-driver-operator
-  version: 4.13.0
+  version: 4.14.0
   maturity: preview
   maintainers:
     - email: aos-storage-staff@redhat.com
@@ -46,7 +46,7 @@ spec:
     name: Red Hat
   labels:
     alm-owner-metering: gcp-filestore-csi-driver-operator
-    alm-status-descriptors: gcp-filestore-csi-driver-operator.v4.13.0
+    alm-status-descriptors: gcp-filestore-csi-driver-operator.v4.14.0
   selector:
     matchLabels:
       alm-owner-metering: gcp-filestore-csi-driver-operator


### PR DESCRIPTION
When testing ocp4.14, found that gcp filestore csi operator csv version still 4.13, so filed bug here https://issues.redhat.com/browse/OCPBUGS-11806
