### PR TITLE
STOR-1353: Add extra labels flag to controller

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -52,6 +52,7 @@ spec:
             - --v=${LOG_LEVEL}
             - --nodeid=$(KUBE_NODE_NAME)
             - --controller=true
+            - --extra-labels=kubernetes-io-cluster-${CLUSTER_ID}=owned
           env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: "/etc/cloud-sa/service_account.json"


### PR DESCRIPTION
Make use of the new flag added by https://github.com/openshift/gcp-filestore-csi-driver/pull/17
The flag itself was copied from the GCP PD operator: https://github.com/openshift/gcp-pd-csi-driver-operator/blob/master/assets/controller.yaml#L53