### PR TITLE
OCPBUGS-16654: Rename sidecar binding RBACs

### DIFF
--- a/assets/rbac/main_provisioner_binding.yaml
+++ b/assets/rbac/main_provisioner_binding.yaml
@@ -1,7 +1,7 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: gcp-filestore-csi-provisioner-binding
+  name: gcp-filestore-csi-main-provisioner-binding
 subjects:
   - kind: ServiceAccount
     name: gcp-filestore-csi-driver-controller-sa

--- a/assets/rbac/main_resizer_binding.yaml
+++ b/assets/rbac/main_resizer_binding.yaml
@@ -1,7 +1,7 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: gcp-filestore-csi-resizer-binding
+  name: gcp-filestore-csi-main-resizer-binding
 subjects:
   - kind: ServiceAccount
     name: gcp-filestore-csi-driver-controller-sa

--- a/assets/rbac/main_snapshotter_binding.yaml
+++ b/assets/rbac/main_snapshotter_binding.yaml
@@ -1,7 +1,7 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: gcp-filestore-csi-snapshotter-binding
+  name: gcp-filestore-csi-main-snapshotter-binding
 subjects:
   - kind: ServiceAccount
     name: gcp-filestore-csi-driver-controller-sa


### PR DESCRIPTION
Modified bindings must have new unique names to keep upgrade happy. Otherwise:
```
processed event: {TypeMeta:{Kind: APIVersion:} ObjectMeta:{Name:azure-disk-csi-driver-operator.1773c595587b1603 GenerateName: Namespace:openshift-cluster-csi-drivers SelfLink: UID:ef428a3e-51ce-482d-b607-38c79981d484 ResourceVersion:55120 Generation:0 CreationTimestamp:2023-07-21 03:52:10 +0000 UTC DeletionTimestamp:<nil> DeletionGracePeriodSeconds:<nil> Labels:map[] Annotations:map[monitor.openshift.io/observed-recreation-count: monitor.openshift.io/observed-update-count:1] OwnerReferences:[] Finalizers:[] ManagedFields:[{Manager:azure-disk-csi-driver-operator Operation:Update APIVersion:v1 Time:2023-07-21 03:52:13 +0000 UTC FieldsType:FieldsV1 FieldsV1:{"f:count":{},"f:firstTimestamp":{},"f:involvedObject":{},"f:lastTimestamp":{},"f:message":{},"f:reason":{},"f:source":{"f:component":{}},"f:type":{}} Subresource:}]} InvolvedObject:{Kind:Deployment Namespace:openshift-cluster-csi-drivers Name:azure-disk-csi-driver-operator UID:324d87d5-4d51-4574-bd86-684e78506e85 APIVersion:apps/v1 ResourceVersion: FieldPath:} Reason:ClusterRoleBindingUpdateFailed Message:Failed to update ClusterRoleBinding.rbac.authorization.k8s.io/azure-disk-csi-attacher-binding: ClusterRoleBinding.rbac.authorization.k8s.io "azure-disk-csi-attacher-binding" is invalid: roleRef: Invalid value: rbac.RoleRef{APIGroup:"rbac.authorization.k8s.io", Kind:"ClusterRole", Name:"openshift-csi-main-attacher-role"}: cannot change roleRef Source:{Component:azure-disk-csi-driver-operator-azurediskdriverstaticresourcescontroller-azurediskdriverstaticresourcescontroller Host:} FirstTimestamp:2023-07-21 03:52:10 +0000 UTC LastTimestamp:2023-07-21 03:52:13 +0000 UTC Count:2 Type:Warning EventTime:0001-01-01 00:00:00 +0000 UTC Series:nil Action: Related:nil ReportingController: ReportingInstance:}
```