### PR TITLE
OCPBUGS-29677: Add infrastructure annotations

### DIFF
--- a/config/manifests/stable/gcp-filestore-csi-driver-operator.clusterserviceversion.yaml
+++ b/config/manifests/stable/gcp-filestore-csi-driver-operator.clusterserviceversion.yaml
@@ -14,6 +14,14 @@ metadata:
     createdAt: "2021-07-14T00:00:00Z"
     description: Install and configure GCP Filestore CSI driver.
     olm.skipRange: ">=4.11.0-0 <4.15.0"
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "true"
+    features.operators.openshift.io/proxy-aware: "true"
+    features.operators.openshift.io/tls-profiles: "true"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
+    features.operators.openshift.io/csi: "true"
   labels:
     operator-metering: "true"
     "operatorframework.io/arch.amd64": supported


### PR DESCRIPTION
All required infrastructure-required annotations are added, plus the CSI one, which is optional.

CC @openshift/storage 