### PR TITLE
CFE-877: Add resourceTags in Infrastructure to driver args list

### DIFF
--- a/assets/credentials.yaml
+++ b/assets/credentials.yaml
@@ -18,6 +18,10 @@ spec:
     kind: GCPProviderSpec
     predefinedRoles:
       - roles/file.editor
+      - roles/resourcemanager.tagUser
     # If set to true, don't check whether the requested
     # roles have the necessary services enabled
-    skipServiceCheck: false
+    # roles/resourcemanager.tagUser requires certain services to be activated
+    # which are not necessarily required for creating OpenShift cluster required
+    # resources. Hence skipping service check.
+    skipServiceCheck: true


### PR DESCRIPTION
PR has the changes for https://github.com/openshift/enhancements/pull/1217 proposed to support GCP tags in OCP, which requires gcp-filestore-csi-driver-operator to add gcp resourceTags available in the status sub-resource of infrastructure CR, to the gcp resources created by the driver.