### PR TITLE
[4.17] OCPBUGS-38736: Some CSI driver containers missing terminationMessagePolicy

### DIFF
--- a/config/manifests/stable/gcp-filestore-csi-driver-operator.clusterserviceversion.yaml
+++ b/config/manifests/stable/gcp-filestore-csi-driver-operator.clusterserviceversion.yaml
@@ -384,6 +384,7 @@ spec:
                     requests:
                       memory: 50Mi
                       cpu: 10m
+                  terminationMessagePolicy: FallbackToLogsOnError
                 priorityClassName: system-cluster-critical
                 # Strongly prefer a master node, but don't require it.
                 # We want the same Deployment to work on hypershift,


### PR DESCRIPTION
Manual backport of https://github.com/openshift/gcp-filestore-csi-driver-operator/pull/99
/cc @openshift/storage
