### PR TITLE
OCPBUGS-56998: enable nfs-export-options feature

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -52,6 +52,7 @@ spec:
             - --v=${LOG_LEVEL}
             - --nodeid=$(KUBE_NODE_NAME)
             - --controller=true
+            - --feature-nfs-export-options=true
           env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: "/etc/cloud-sa/service_account.json"


### PR DESCRIPTION
During the rebase of gcp-filestore-csi-driver the `nfs-export-options-on-create` feature got added, but we did not allow it in our operator, this PR turns it on.