### PR TITLE
STOR-2331: Add labels to subscribe GCP Filestore CSI driver operator to NPs

### DIFF
--- a/config/manifests/stable/gcp-filestore-csi-driver-operator.clusterserviceversion.yaml
+++ b/config/manifests/stable/gcp-filestore-csi-driver-operator.clusterserviceversion.yaml
@@ -384,6 +384,9 @@ spec:
                   target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
                 labels:
                   app: gcp-filestore-csi-driver-operator
+                  openshift.storage.network-policy.dns: allow
+                  openshift.storage.network-policy.api-server: allow
+                  openshift.storage.network-policy.operator-metrics-range: allow
               spec:
                 serviceAccountName: gcp-filestore-csi-driver-operator
                 containers:


### PR DESCRIPTION
https://issues.redhat.com//browse/STOR-2331

This PR subscribes GCP Filestore CSI driver operator pods to NPs from https://github.com/openshift/cluster-storage-operator/pull/579