### PR TITLE
STOR-2920: Bump OLM metadata to 5.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ IMAGE_REGISTRY?=registry.svc.ci.openshift.org
 # $3 - Dockerfile path
 # $4 - context directory for image build
 # It will generate target "image-$(1)" for building the image and binding it as a prerequisite to target "images".
-$(call build-image,gcp-filestore-csi-driver-operator,$(IMAGE_REGISTRY)/ocp/4.22:gcp-filestore-csi-driver-operator,./Dockerfile.rhel7,.)
+$(call build-image,gcp-filestore-csi-driver-operator,$(IMAGE_REGISTRY)/ocp/5.0:gcp-filestore-csi-driver-operator,./Dockerfile.rhel7,.)
 
 clean: clean-yq
 	$(RM) gcp-filestore-csi-driver-operator

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ To build an bundle and index images, use the `hack/create-bundle` script:
 
 ```shell
 cd hack
-./create-bundle registry.ci.openshift.org/ocp/4.22:gcp-filestore-csi-driver registry.ci.openshift.org/ocp/4.22:gcp-filestore-csi-driver-operator quay.io/<my_user>/filestore-bundle quay.io/<my_user>/filestore-index
+./create-bundle registry.ci.openshift.org/ocp/5.0:gcp-filestore-csi-driver registry.ci.openshift.org/ocp/5.0:gcp-filestore-csi-driver-operator quay.io/<my_user>/filestore-bundle quay.io/<my_user>/filestore-index
 ```
 
 At the end it will print a command that creates `Subscription` for the newly created index image.

--- a/config/manifests/gcp-filestore-csi-driver-operator.package.yaml
+++ b/config/manifests/gcp-filestore-csi-driver-operator.package.yaml
@@ -1,4 +1,4 @@
 packageName: gcp-filestore-csi-driver-operator
 channels:
   - name: stable
-    currentCSV: gcp-filestore-csi-driver-operator.v4.22.0
+    currentCSV: gcp-filestore-csi-driver-operator.v5.0.0

--- a/config/manifests/stable/gcp-filestore-csi-driver-operator.clusterserviceversion.yaml
+++ b/config/manifests/stable/gcp-filestore-csi-driver-operator.clusterserviceversion.yaml
@@ -1,7 +1,7 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
-  name: gcp-filestore-csi-driver-operator.v4.22.0
+  name: gcp-filestore-csi-driver-operator.v5.0.0
   namespace: placeholder
   annotations:
     categories: Storage
@@ -13,8 +13,8 @@ metadata:
     repository: https://github.com/openshift/gcp-filestore-csi-driver-operator
     createdAt: "2021-07-14T00:00:00Z"
     description: Install and configure GCP Filestore CSI driver.
-    olm.properties: '[{"type":"olm.maxOpenShiftVersion","value":"4.23"}]'
-    olm.skipRange: ">=4.11.0-0 <4.22.0"
+    olm.properties: '[{"type":"olm.maxOpenShiftVersion","value":"5.1"}]'
+    olm.skipRange: ">=4.11.0-0 <5.0.0"
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
     features.operators.openshift.io/proxy-aware: "true"
@@ -43,7 +43,7 @@ spec:
       url: https://github.com/openshift/gcp-filestore-csi-driver-operator
     - name: Source Repository
       url: https://github.com/openshift/gcp-filestore-csi-driver-operator
-  version: 4.22.0
+  version: 5.0.0
   maturity: stable
   maintainers:
     - email: aos-storage-staff@redhat.com
@@ -53,7 +53,7 @@ spec:
     name: Red Hat
   labels:
     alm-owner-metering: gcp-filestore-csi-driver-operator
-    alm-status-descriptors: gcp-filestore-csi-driver-operator.v4.22.0
+    alm-status-descriptors: gcp-filestore-csi-driver-operator.v5.0.0
   selector:
     matchLabels:
       alm-owner-metering: gcp-filestore-csi-driver-operator


### PR DESCRIPTION
https://redhat.atlassian.net/browse/STOR-2920

Changes generated with:

`make metadata OCP_VERSION=5.0.0`

/cc @openshift/storage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GCP Filestore CSI Driver Operator to version v5.0.0 with corresponding package manifest changes
  * Updated build process and image references to support OpenShift Platform v5.0
  * Adjusted operator compatibility constraints to define maximum supported OpenShift version and applicable upgrade paths

<!-- end of auto-generated comment: release notes by coderabbit.ai -->