### PR TITLE
OCPBUGS-85106: Add required-scc annotation to managed workloads

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -21,6 +21,7 @@ spec:
         app: gcp-filestore-csi-driver-controller
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: privileged
     spec:
       hostNetwork: true
       serviceAccountName: gcp-filestore-csi-driver-controller-sa

--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -20,6 +20,7 @@ spec:
         app: gcp-filestore-csi-driver-node
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: privileged
         # This annotation prevents eviction from the cluster-autoscaler
         cluster-autoscaler.kubernetes.io/enable-ds-eviction: "false"
     spec:

--- a/config/manifests/stable/gcp-filestore-csi-driver-operator.clusterserviceversion.yaml
+++ b/config/manifests/stable/gcp-filestore-csi-driver-operator.clusterserviceversion.yaml
@@ -384,6 +384,7 @@ spec:
               metadata:
                 annotations:
                   target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+                  openshift.io/required-scc: restricted-v2
                 labels:
                   app: gcp-filestore-csi-driver-operator
                   openshift.storage.network-policy.dns: allow


### PR DESCRIPTION
Failing sippy tests: https://sippy.dptools.openshift.org/sippy-ng/tests/5.0/analysis?test=%5BMonitor%3Arequired-scc-annotation-checker%5D%5Bsig-auth%5D%20all%20workloads%20in%20ns%2Fopenshift-cluster-csi-drivers%20must%20set%20the%20%27openshift.io%2Frequired-scc%27%20annotation

We're planning on fixing all remaining workloads in `ns/openshift-cluster-csi-drivers` so that we can drop the [exception](https://github.com/openshift/origin/blob/main/pkg/monitortests/authentication/requiredsccmonitortests/monitortest.go#L42) from the required-scc-annotation-checker monitor test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenShift security constraint configurations for controller, node, and operator components to specify required security context constraints for proper deployment and execution on OpenShift clusters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->