### PR TITLE
[4.22] OCPBUGS-91947: maxOpenShiftVersion should be bumped to 5.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ BIN_PATH=$(CURPATH)/bin
 YQ = $(BIN_PATH)/yq
 YQ_VERSION = v4.47.1
 export PATH := $(BIN_PATH):$(PATH)
+export MAX_OCP_VERSION := 5.0
 
 all: build
 .PHONY: all

--- a/config/manifests/stable/gcp-filestore-csi-driver-operator.clusterserviceversion.yaml
+++ b/config/manifests/stable/gcp-filestore-csi-driver-operator.clusterserviceversion.yaml
@@ -13,7 +13,7 @@ metadata:
     repository: https://github.com/openshift/gcp-filestore-csi-driver-operator
     createdAt: "2021-07-14T00:00:00Z"
     description: Install and configure GCP Filestore CSI driver.
-    olm.properties: '[{"type":"olm.maxOpenShiftVersion","value":"4.23"}]'
+    olm.properties: '[{"type":"olm.maxOpenShiftVersion","value":"5.0"}]'
     olm.skipRange: ">=4.11.0-0 <4.22.0"
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"

--- a/hack/update-metadata.sh
+++ b/hack/update-metadata.sh
@@ -13,6 +13,9 @@ set -o pipefail
 #   using the current package version, or you can for example run
 #   `./hack/update-metadata.sh 4.20` to set the package version to 4.20.
 #   Both PACKAGE_MANIFEST and CSV_MANIFEST will be updated by this script.
+#
+#   MAX_OCP_VERSION defaults to the next minor version after OCP_VERSION, but
+#   can be overwritten by setting the MAX_OCP_VERSION environment variable.
 
 
 PACKAGE_MANIFEST=config/manifests/gcp-filestore-csi-driver-operator.package.yaml
@@ -50,11 +53,12 @@ PATCH_VERSION=${PATCH_VERSION:-0}
 if [ "${OCP_VERSION}" != "${PACKAGE_VERSION}" ]; then
 	PACKAGE_VERSION="${MAJOR_VERSION}.${MINOR_VERSION}.${PATCH_VERSION}"
 fi
+MAX_OCP_VERSION=${MAX_OCP_VERSION:-"${MAJOR_VERSION}.$((MINOR_VERSION + 1))"}
 
 export NEW_CURRENT_CSV="${PACKAGE_NAME}.v${PACKAGE_VERSION}"
 export NEW_METADATA_NAME="${PACKAGE_NAME}.v${PACKAGE_VERSION}"
 export NEW_SKIP_RANGE=$(echo ${SKIP_RANGE} | sed "s/ <.*$/ <${PACKAGE_VERSION}/")
-export NEW_OLM_PROPERTIES=$(echo "${OLM_PROPERTIES}" | jq -c 'map(if .type=="olm.maxOpenShiftVersion" then .value="'${MAJOR_VERSION}.$((MINOR_VERSION + 1))'" else . end)')
+export NEW_OLM_PROPERTIES=$(echo "${OLM_PROPERTIES}" | jq -c 'map(if .type=="olm.maxOpenShiftVersion" then .value="'${MAX_OCP_VERSION}'" else . end)')
 export NEW_SPEC_VERSION="${PACKAGE_VERSION}"
 export NEW_ALM_STATUS_DESC="${PACKAGE_NAME}.v${PACKAGE_VERSION}"
 


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OCPBUGS-91947

This PR allows setting `MAX_OCP_VERSION` as an environment variable for releases where the default x.y+1 max version is incorrect and pins the release-4.22 branch `MAX_OCP_VERSION` to 5.0.

- **hack/update-metadata.sh: allow MAX_OCP_VERSION override**
- **Makefile: pin MAX_OCP_VERSION to 5.0**

/cc @openshift/storage
