### PR TITLE
STOR-3055: implement TLS Adherence in GCP Filestore

### DIFF
--- a/cmd/gcp-filestore-csi-driver-operator/main.go
+++ b/cmd/gcp-filestore-csi-driver-operator/main.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"context"
+	"fmt"
 	"os"
+	"time"
 
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
 	"github.com/spf13/cobra"
@@ -36,6 +39,32 @@ func NewOperatorCommand() *cobra.Command {
 	).NewCommand()
 	ctrlCmd.Use = "start"
 	ctrlCmd.Short = "Start the GCP Filestore CSI Driver Operator"
+
+	// Inject cluster TLS profile into the operator's own HTTPS endpoint before
+	// controllercmd starts the server. This is an OLM-managed operator so it
+	// must read the APIServer CR itself — CVO/CSO do not inject TLS config.
+	// See: openshift/enhancements#1910
+	originalPreRunE := ctrlCmd.PersistentPreRunE
+	ctrlCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		if originalPreRunE != nil {
+			if err := originalPreRunE(cmd, args); err != nil {
+				return err
+			}
+		}
+
+		ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
+		defer cancel()
+		configPath, err := operator.WriteOperatorTLSConfig(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to configure TLS profile: %w", err)
+		}
+		if configPath != "" {
+			if err := cmd.Flags().Set("config", configPath); err != nil {
+				return fmt.Errorf("failed to set --config flag: %w", err)
+			}
+		}
+		return nil
+	}
 
 	cmd.AddCommand(ctrlCmd)
 

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -14,11 +14,14 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	apiextclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/client-go/dynamic"
 	kubeclient "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
+	configv1 "github.com/openshift/api/config/v1"
 	opv1 "github.com/openshift/api/operator/v1"
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	configinformers "github.com/openshift/client-go/config/informers/externalversions"
@@ -76,6 +79,20 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 	configClient := configclient.NewForConfigOrDie(rest.AddUserAgent(controllerConfig.KubeConfig, operatorName))
 	configInformers := configinformers.NewSharedInformerFactory(configClient, 20*time.Minute)
 	infraInformer := configInformers.Config().V1().Infrastructures()
+
+	// Set up a cancellable context so we can restart the operator when TLS profile changes.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// Watch for TLS profile or adherence changes on the APIServer CR and restart the
+	// operator process so it picks up the new configuration. The CSIConfigObserverController
+	// handles re-syncing the CSI driver deployment with new TLS values, but the operator
+	// process itself needs a restart to apply any changes to its own serving configuration.
+	if _, err := configInformers.Config().V1().APIServers().Informer().AddEventHandler(
+		newAPIServerTLSChangeHandler(cancel),
+	); err != nil {
+		return fmt.Errorf("failed to add APIServer TLS profile change handler: %w", err)
+	}
 
 	// Create GenericOperatorclient. This is used by the library-go controllers created down below
 	operatorClient, dynamicInformers, err := goc.NewClusterScopedOperatorClientWithConfigName(
@@ -219,6 +236,28 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 	<-ctx.Done()
 
 	return nil
+}
+
+func newAPIServerTLSChangeHandler(cancel context.CancelFunc) cache.ResourceEventHandlerFuncs {
+	return cache.ResourceEventHandlerFuncs{
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			oldAPI, ok1 := oldObj.(*configv1.APIServer)
+			newAPI, ok2 := newObj.(*configv1.APIServer)
+			if !ok1 || !ok2 {
+				return
+			}
+			if !equality.Semantic.DeepEqual(oldAPI.Spec.TLSSecurityProfile, newAPI.Spec.TLSSecurityProfile) {
+				klog.Infof("Cluster TLS security profile changed, restarting operator to apply new configuration")
+				cancel()
+				return
+			}
+			if oldAPI.Spec.TLSAdherence != newAPI.Spec.TLSAdherence {
+				klog.Infof("TLS adherence policy changed from %q to %q, restarting operator", oldAPI.Spec.TLSAdherence, newAPI.Spec.TLSAdherence)
+				cancel()
+				return
+			}
+		},
+	}
 }
 
 func mustReplaceNamespace(namespace, file string) []byte {

--- a/pkg/operator/starter_test.go
+++ b/pkg/operator/starter_test.go
@@ -1,6 +1,7 @@
 package operator
 
 import (
+	"context"
 	"fmt"
 	opv1 "github.com/openshift/api/operator/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -376,6 +377,96 @@ func TestWIFCredentialsRequestHook(t *testing.T) {
 					}
 				}
 			}
+		})
+	}
+}
+
+func TestTLSProfileChangeHandler(t *testing.T) {
+	intermediateProfile := &v1.TLSSecurityProfile{
+		Type: v1.TLSProfileIntermediateType,
+	}
+	modernProfile := &v1.TLSSecurityProfile{
+		Type: v1.TLSProfileModernType,
+	}
+
+	tests := []struct {
+		name       string
+		oldObj     interface{}
+		newObj     interface{}
+		wantCancel bool
+	}{
+		{
+			name: "TLSSecurityProfile changed triggers cancel",
+			oldObj: &v1.APIServer{
+				Spec: v1.APIServerSpec{
+					TLSSecurityProfile: intermediateProfile,
+				},
+			},
+			newObj: &v1.APIServer{
+				Spec: v1.APIServerSpec{
+					TLSSecurityProfile: modernProfile,
+				},
+			},
+			wantCancel: true,
+		},
+		{
+			name: "TLSAdherence changed triggers cancel",
+			oldObj: &v1.APIServer{
+				Spec: v1.APIServerSpec{
+					TLSAdherence: v1.TLSAdherencePolicyLegacyAdheringComponentsOnly,
+				},
+			},
+			newObj: &v1.APIServer{
+				Spec: v1.APIServerSpec{
+					TLSAdherence: v1.TLSAdherencePolicyStrictAllComponents,
+				},
+			},
+			wantCancel: true,
+		},
+		{
+			name: "no change does not trigger cancel",
+			oldObj: &v1.APIServer{
+				Spec: v1.APIServerSpec{
+					TLSSecurityProfile: intermediateProfile,
+					TLSAdherence:       v1.TLSAdherencePolicyLegacyAdheringComponentsOnly,
+				},
+			},
+			newObj: &v1.APIServer{
+				Spec: v1.APIServerSpec{
+					TLSSecurityProfile: intermediateProfile,
+					TLSAdherence:       v1.TLSAdherencePolicyLegacyAdheringComponentsOnly,
+				},
+			},
+			wantCancel: false,
+		},
+		{
+			name:       "wrong type does not panic",
+			oldObj:     "not-an-apiserver",
+			newObj:     "not-an-apiserver",
+			wantCancel: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			cancelled := false
+			testCancel := func() {
+				cancelled = true
+				cancel()
+			}
+
+			handler := newAPIServerTLSChangeHandler(testCancel)
+
+			handler.UpdateFunc(tt.oldObj, tt.newObj)
+
+			if cancelled != tt.wantCancel {
+				t.Errorf("cancel called = %v, want %v", cancelled, tt.wantCancel)
+			}
+
+			_ = ctx
 		})
 	}
 }

--- a/pkg/operator/tlsconfig.go
+++ b/pkg/operator/tlsconfig.go
@@ -1,0 +1,110 @@
+package operator
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
+
+	configv1 "github.com/openshift/api/config/v1"
+	configclient "github.com/openshift/client-go/config/clientset/versioned"
+	"github.com/openshift/library-go/pkg/crypto"
+)
+
+// WriteOperatorTLSConfig reads the cluster TLS profile from the APIServer CR
+// and writes a GenericOperatorConfig file with TLS settings for the operator's
+// own HTTPS endpoint (metrics, healthz).
+// Returns empty string when running outside a cluster (local development).
+// Returns an error when the APIServer CR cannot be read.
+func WriteOperatorTLSConfig(ctx context.Context) (string, error) {
+	restConfig, err := rest.InClusterConfig()
+	if err != nil {
+		klog.V(4).Infof("Not running in-cluster, skipping TLS profile injection: %v", err)
+		return "", nil
+	}
+
+	client, err := configclient.NewForConfig(restConfig)
+	if err != nil {
+		return "", fmt.Errorf("failed to create config client: %w", err)
+	}
+
+	apiServer, err := client.ConfigV1().APIServers().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to read APIServer config: %w", err)
+	}
+
+	var profile *configv1.TLSSecurityProfile
+	if crypto.ShouldHonorClusterTLSProfile(apiServer.Spec.TLSAdherence) {
+		profile = apiServer.Spec.TLSSecurityProfile
+		klog.Infof("TLS adherence policy is %q, using cluster TLS profile", apiServer.Spec.TLSAdherence)
+	} else {
+		klog.Infof("TLS adherence policy is %q, using default Intermediate profile", apiServer.Spec.TLSAdherence)
+	}
+
+	return writeConfig(resolveTLSProfile(profile))
+}
+
+func writeConfig(minTLSVersion string, cipherSuites []string) (string, error) {
+	configDir := "/tmp/gcp-filestore-operator-tls"
+	if err := os.MkdirAll(configDir, 0700); err != nil {
+		return "", fmt.Errorf("failed to create TLS config dir: %w", err)
+	}
+
+	configPath := filepath.Join(configDir, "config.yaml")
+	content := buildOperatorConfig(minTLSVersion, cipherSuites)
+
+	if err := os.WriteFile(configPath, []byte(content), 0600); err != nil {
+		return "", fmt.Errorf("failed to write operator TLS config: %w", err)
+	}
+
+	klog.Infof("Wrote operator TLS config to %s (minTLSVersion=%s, %d cipher suites)", configPath, minTLSVersion, len(cipherSuites))
+	return configPath, nil
+}
+
+// resolveTLSProfile resolves a TLSSecurityProfile to concrete minTLSVersion and
+// IANA cipher suite names. When profile is nil, defaults to Intermediate.
+func resolveTLSProfile(profile *configv1.TLSSecurityProfile) (string, []string) {
+	if profile == nil {
+		spec := configv1.TLSProfiles[crypto.DefaultTLSProfileType]
+		return string(spec.MinTLSVersion), crypto.OpenSSLToIANACipherSuites(spec.Ciphers)
+	}
+
+	var spec *configv1.TLSProfileSpec
+	switch profile.Type {
+	case configv1.TLSProfileCustomType:
+		if profile.Custom != nil {
+			spec = &profile.Custom.TLSProfileSpec
+		}
+	case configv1.TLSProfileOldType, configv1.TLSProfileIntermediateType, configv1.TLSProfileModernType:
+		spec = configv1.TLSProfiles[profile.Type]
+	}
+
+	if spec == nil {
+		spec = configv1.TLSProfiles[crypto.DefaultTLSProfileType]
+	}
+
+	return string(spec.MinTLSVersion), crypto.OpenSSLToIANACipherSuites(spec.Ciphers)
+}
+
+func buildOperatorConfig(minTLSVersion string, cipherSuites []string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, `apiVersion: operator.openshift.io/v1alpha1
+kind: GenericOperatorConfig
+servingInfo:
+  minTLSVersion: %s
+`, minTLSVersion)
+
+	if len(cipherSuites) > 0 {
+		b.WriteString("  cipherSuites:\n")
+		for _, cs := range cipherSuites {
+			fmt.Fprintf(&b, "  - %s\n", cs)
+		}
+	}
+
+	return b.String()
+}

--- a/pkg/operator/tlsconfig_test.go
+++ b/pkg/operator/tlsconfig_test.go
@@ -1,0 +1,162 @@
+package operator
+
+import (
+	"strings"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+func TestResolveTLSProfile(t *testing.T) {
+	tests := []struct {
+		name            string
+		profile         *configv1.TLSSecurityProfile
+		wantMinVersion  string
+		wantCipherCount int
+		wantFirstCipher string
+	}{
+		{
+			name:           "nil profile defaults to Intermediate",
+			profile:        nil,
+			wantMinVersion: string(configv1.TLSProfiles[configv1.TLSProfileIntermediateType].MinTLSVersion),
+		},
+		{
+			name: "Old profile",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileOldType,
+			},
+			wantMinVersion: string(configv1.TLSProfiles[configv1.TLSProfileOldType].MinTLSVersion),
+		},
+		{
+			name: "Intermediate profile",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileIntermediateType,
+			},
+			wantMinVersion: string(configv1.TLSProfiles[configv1.TLSProfileIntermediateType].MinTLSVersion),
+		},
+		{
+			name: "Modern profile",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileModernType,
+			},
+			wantMinVersion: string(configv1.TLSProfiles[configv1.TLSProfileModernType].MinTLSVersion),
+		},
+		{
+			name: "Custom profile with spec",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						MinTLSVersion: configv1.VersionTLS12,
+						Ciphers:       []string{"ECDHE-RSA-AES128-GCM-SHA256"},
+					},
+				},
+			},
+			wantMinVersion:  string(configv1.VersionTLS12),
+			wantCipherCount: 1,
+			wantFirstCipher: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+		},
+		{
+			name: "Custom profile with nil Custom spec falls back to Intermediate",
+			profile: &configv1.TLSSecurityProfile{
+				Type:   configv1.TLSProfileCustomType,
+				Custom: nil,
+			},
+			wantMinVersion: string(configv1.TLSProfiles[configv1.TLSProfileIntermediateType].MinTLSVersion),
+		},
+		{
+			name: "Unknown profile type falls back to Intermediate",
+			profile: &configv1.TLSSecurityProfile{
+				Type: "UnknownType",
+			},
+			wantMinVersion: string(configv1.TLSProfiles[configv1.TLSProfileIntermediateType].MinTLSVersion),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			minVersion, ciphers := resolveTLSProfile(tt.profile)
+
+			if minVersion != tt.wantMinVersion {
+				t.Errorf("minTLSVersion = %q, want %q", minVersion, tt.wantMinVersion)
+			}
+
+			if tt.wantCipherCount > 0 && len(ciphers) != tt.wantCipherCount {
+				t.Errorf("cipher count = %d, want %d", len(ciphers), tt.wantCipherCount)
+			}
+
+			if tt.wantFirstCipher != "" && (len(ciphers) == 0 || ciphers[0] != tt.wantFirstCipher) {
+				got := ""
+				if len(ciphers) > 0 {
+					got = ciphers[0]
+				}
+				t.Errorf("first cipher = %q, want %q", got, tt.wantFirstCipher)
+			}
+
+			if tt.wantCipherCount == 0 && len(ciphers) == 0 {
+				t.Error("expected non-empty cipher list for standard profiles")
+			}
+		})
+	}
+}
+
+func TestBuildOperatorConfig(t *testing.T) {
+	tests := []struct {
+		name         string
+		minVersion   string
+		cipherSuites []string
+		wantContains []string
+		wantAbsent   []string
+	}{
+		{
+			name:         "standard config with ciphers",
+			minVersion:   "VersionTLS12",
+			cipherSuites: []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"},
+			wantContains: []string{
+				"apiVersion: operator.openshift.io/v1alpha1",
+				"kind: GenericOperatorConfig",
+				"minTLSVersion: VersionTLS12",
+				"cipherSuites:",
+				"  - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+				"  - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+			},
+		},
+		{
+			name:         "config without ciphers",
+			minVersion:   "VersionTLS13",
+			cipherSuites: nil,
+			wantContains: []string{
+				"minTLSVersion: VersionTLS13",
+			},
+			wantAbsent: []string{
+				"cipherSuites:",
+			},
+		},
+		{
+			name:         "empty cipher slice",
+			minVersion:   "VersionTLS12",
+			cipherSuites: []string{},
+			wantAbsent: []string{
+				"cipherSuites:",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildOperatorConfig(tt.minVersion, tt.cipherSuites)
+
+			for _, want := range tt.wantContains {
+				if !strings.Contains(result, want) {
+					t.Errorf("output missing expected content %q\ngot:\n%s", want, result)
+				}
+			}
+
+			for _, absent := range tt.wantAbsent {
+				if strings.Contains(result, absent) {
+					t.Errorf("output should not contain %q\ngot:\n%s", absent, result)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic TLS configuration for the operator based on cluster security settings.
  * The operator now applies updated TLS security profiles without requiring a manual restart.
  * Startup continues with safe defaults if TLS configuration cannot be retrieved or applied.

* **Bug Fixes**
  * Improved resilience when cluster API access or TLS configuration setup fails.
  * Added safeguards to prevent invalid configuration changes from interrupting startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

cc @openshift/storage 