### PR TITLE
OCPBUGS-99201: Add networking.k8s.io/networkpolicies RBAC

### DIFF
--- a/config/manifests/stable/gcp-filestore-csi-driver-operator.clusterserviceversion.yaml
+++ b/config/manifests/stable/gcp-filestore-csi-driver-operator.clusterserviceversion.yaml
@@ -372,6 +372,14 @@ spec:
                 - get
                 - list
                 - watch
+            - apiGroups:
+                - networking.k8s.io
+              resources:
+                - networkpolicies
+              verbs:
+                - create
+                - delete
+                - update
           serviceAccountName: gcp-filestore-csi-driver-operator
       deployments:
         - name: gcp-filestore-csi-driver-operator


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OCPBUGS-99201

Add `networking.k8s.io/networkpolicies` RBAC permissions (`create`, `delete`, `update`) to the `clusterPermissions` section of the ClusterServiceVersion to pass the `olm.required_network_policy_rbac_for_operands` Conforma check, which becomes a release blocker on August 8th.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved operator support for managing cluster network policies.
  * Added permissions required to create, update, and delete network policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->